### PR TITLE
Packet 0204: mermaid calltree

### DIFF
--- a/src/ctrlr/__init__.py
+++ b/src/ctrlr/__init__.py
@@ -1,5 +1,6 @@
 from .contracts import Lens, Phase, Pillar, RunCapsule, Span, Step
 from .control import CtrlrError, ensure, invariant, require
+from .mermaid import to_mermaid_calltree
 from .trace import current_lens, current_span_id, read_jsonl, run, span, step, write_jsonl
 
 __all__ = [
@@ -17,6 +18,7 @@ __all__ = [
     "read_jsonl",
     "require",
     "run",
+    "to_mermaid_calltree",
     "span",
     "step",
     "write_jsonl",

--- a/src/ctrlr/mermaid.py
+++ b/src/ctrlr/mermaid.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+from .contracts import Span
+
+
+@dataclass(frozen=True)
+class _SpanNode:
+    span_id: str
+    name: str
+    parent_span_id: str | None
+
+
+def _normalize_span(item: Span | dict) -> _SpanNode:
+    if isinstance(item, Span):
+        return _SpanNode(span_id=item.span_id, name=item.name, parent_span_id=item.parent_span_id)
+    if isinstance(item, dict):
+        if "span_id" not in item or "name" not in item:
+            raise ValueError("span must include span_id and name")
+        return _SpanNode(
+            span_id=str(item["span_id"]),
+            name=str(item["name"]),
+            parent_span_id=item.get("parent_span_id"),
+        )
+    raise TypeError("span must be Span or dict")
+
+
+def _safe_id(raw_id: str, prefix: str) -> str:
+    out = []
+    for ch in raw_id:
+        if ch.isalnum() or ch == "_":
+            out.append(ch)
+        else:
+            out.append("_")
+    return prefix + "".join(out)
+
+
+def _escape_label(text: str) -> str:
+    return (
+        text.replace("\\", "\\\\")
+        .replace("\"", "\\\"")
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+    )
+
+
+def _detect_self_cycle(nodes: list[_SpanNode]) -> None:
+    for node in nodes:
+        if node.parent_span_id == node.span_id:
+            raise ValueError("span parent cycle detected")
+
+
+def to_mermaid_calltree(spans: Iterable[Span | dict]) -> str:
+    """Render a deterministic Mermaid calltree from ordered spans."""
+    nodes = [_normalize_span(s) for s in spans]
+    node_ids = {n.span_id for n in nodes}
+    _detect_self_cycle(nodes)
+
+    lines = ["flowchart TD"]
+    root_id = "ROOT"
+    lines.append(f'  {root_id}["root"]')
+
+    for node in nodes:
+        node_id = _safe_id(node.span_id, "SPAN_")
+        label = _escape_label(f"{node.span_id}: {node.name}")
+        lines.append(f'  {node_id}["{label}"]')
+
+    for node in nodes:
+        parent = node.parent_span_id
+        if parent is None or parent not in node_ids:
+            lines.append(f"  {root_id} --> {_safe_id(node.span_id, 'SPAN_')}")
+        else:
+            lines.append(f"  {_safe_id(parent, 'SPAN_')} --> {_safe_id(node.span_id, 'SPAN_')}")
+
+    return "\n".join(lines) + "\n"

--- a/tests/test_mermaid_calltree.py
+++ b/tests/test_mermaid_calltree.py
@@ -1,0 +1,51 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from ctrlr import Span, to_mermaid_calltree
+
+
+def test_mermaid_calltree_golden() -> None:
+    spans = [
+        Span(span_id="s1", name="root"),
+        Span(span_id="s2", name='child "a"', parent_span_id="s1"),
+        Span(span_id="s3", name="leaf\nline", parent_span_id="s2"),
+    ]
+    out = to_mermaid_calltree(spans)
+    expected = (
+        "flowchart TD\n"
+        '  ROOT["root"]\n'
+        '  SPAN_s1["s1: root"]\n'
+        '  SPAN_s2["s2: child \\"a\\""]\n'
+        '  SPAN_s3["s3: leaf\\nline"]\n'
+        "  ROOT --> SPAN_s1\n"
+        "  SPAN_s1 --> SPAN_s2\n"
+        "  SPAN_s2 --> SPAN_s3\n"
+    )
+    assert out == expected
+
+
+def test_mermaid_calltree_missing_parent_attaches_root() -> None:
+    spans = [
+        {"span_id": "a", "name": "A", "parent_span_id": "missing"},
+        {"span_id": "b", "name": "B"},
+    ]
+    out = to_mermaid_calltree(spans)
+    assert "ROOT --> SPAN_a" in out
+    assert "ROOT --> SPAN_b" in out
+
+
+def test_mermaid_calltree_cycle_raises() -> None:
+    spans = [
+        {"span_id": "x", "name": "X", "parent_span_id": "x"},
+    ]
+    try:
+        to_mermaid_calltree(spans)
+    except ValueError as exc:
+        assert "cycle" in str(exc)
+    else:
+        raise AssertionError("expected ValueError")


### PR DESCRIPTION
Adds to_mermaid_calltree() with deterministic output and cycle handling. Evidence: .codex/out/packet-ctrlr-0204-mermaid-calltree/ (tests PASS).